### PR TITLE
Refactor 'ask' Function for More Robust Error Handling

### DIFF
--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -1,3 +1,4 @@
+
 import OpenAI from 'openai';
 
 const openai = new OpenAI();
@@ -9,9 +10,22 @@ export const ask = async (prompt: string): Promise<string> => {
     messages: [{ role: 'user', content: prompt }],
     model: MODEL,
   });
+
+  // Check if response contains choices object, its first element and the message object
+  if (
+    !chatCompletion.hasOwnProperty('choices') || 
+    !chatCompletion.choices[0] || 
+    !chatCompletion.choices[0].hasOwnProperty('message') || 
+    !chatCompletion.choices[0].message.hasOwnProperty('content')
+  ) {
+    throw new Error('Unexpected format in the response from GPT');
+  }
+
   const response = chatCompletion.choices[0].message.content;
+
   if (response === null) {
     throw new Error('Unexpected null response from GPT');
   }
+
   return response;
 };


### PR DESCRIPTION

Currently, the 'ask' function assumes that the API response will always contain the 'choices' array with at least one element in it which is an object having the 'message' property containing 'content'. This might not always be the case, and if anything goes wrong, it would cause an 'undefined' error which can't be caught properly. We will refactor the function to add an extra layer of error handling to check if the API response contains the required properties and handle potential errors more gracefully.
