### PR TITLE
Refactor refactorFile function to handle errors gracefully

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,3 +1,5 @@
+
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
 
@@ -13,31 +15,36 @@ if (BASE_BRANCH_NAME === undefined) {
 }
 
 const refactorFile = async (fileName: string): Promise<void> => {
-  console.log(`Attempting to refactor ${fileName}`);
-  const file = await getGithubFile({
-    repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
-    fileName,
-  });
-  const pullRequestInfo = await refactor(file);
-  if (pullRequestInfo === undefined) {
-    return;
+  try {
+    console.log(`Attempting to refactor ${fileName}`);
+    const file = await getGithubFile({
+      repository: REPOSITORY,
+      branchName: BASE_BRANCH_NAME,
+      fileName,
+    });
+    const pullRequestInfo = await refactor(file);
+    if (pullRequestInfo === undefined) {
+      return;
+    }
+    await createGithubPullRequest({
+      repository: REPOSITORY,
+      baseBranchName: BASE_BRANCH_NAME,
+      branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+      commitMessage: pullRequestInfo.commitMessage,
+      title: pullRequestInfo.title,
+      description: pullRequestInfo.description,
+      updates: [
+        {
+          fileName,
+          content: pullRequestInfo.content,
+        }
+      ],
+    });
+    console.log(`✅ Refactored ${fileName}`);
   }
-  await createGithubPullRequest({
-    repository: REPOSITORY,
-    baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
-    commitMessage: pullRequestInfo.commitMessage,
-    title: pullRequestInfo.title,
-    description: pullRequestInfo.description,
-    updates: [
-      {
-        fileName,
-        content: pullRequestInfo.content,
-      }
-    ],
-  });
-  console.log(`✅ Refactored ${fileName}`);
+  catch(err) {
+    console.error(`Error while attempting to refactor ${fileName}:`, err);
+  }
 };
 
 export default async (): Promise<void> => {
@@ -54,3 +61,4 @@ export default async (): Promise<void> => {
     .slice(0, 10);
   await Promise.all(filesToRefactor.map(refactorFile));
 };
+```


### PR DESCRIPTION

Currently the function refactorFile makes several network calls without any meaningful error handling. If any of these calls fail, the entire program might crash, depending on the failure mode.

I suggest adding catchError clause on the async functions which will make our function resilient to network issues and prevent failures from breaking the whole operation.

The catchError clauses will catch any error that occur while executing the getGithubFile and createGithubPullRequest functions and log the error to the console. This should make the system more resilient and improve its error reporting.
