### PR TITLE
Refactor Error Handling in Demo's Main Invocation to Include Specific Error Messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+
+```typescript
 import './dotenv';
 import demo from './demo';
 
 demo().catch(e => {
-  console.error('There was an error in the demo.', e);
+    console.error(`There was an error in the demo. Error: ${e.message}. Stack: ${e.stack}`);
 });
+```


### PR DESCRIPTION

In the current implementation, when `demo()` throws an exception it's caught and logged to the console with a generic message "There was an error in the demo.". Now, while it's okay, in many cases, having more specific error messages would enhance debuggability of the code. In this pull request, I have refactored the catch block around `demo()` to include the specific error message along with the stack trace for better understanding and fixing of any issues in the future. This allows developers to quickly understand what type of error occurred without having to parse through stack traces or code.
