### PR TITLE
Refactored 'getContent' regex to correctly capture multi-line contents

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -1,3 +1,4 @@
+
 import { ask } from '../gpt';
 
 const PROMPT = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
@@ -42,7 +43,7 @@ const titlePattern = /^👑 *([\s\S]*?) *👑\n/;
 const descriptionPattern = /\n🥔 *([\s\S]*?) *🥔\n/;
 const commitMessagePattern = /\n🐴 *([\s\S]*?) *🐴\n/;
 const branchNamePattern = /\n🦀 *([\s\S]*?) *🦀\n/;
-const contentPattern = /\n🤖\w*([\s\S]*?) *🤖$/;
+const contentPattern = /\n🤖([\s\S]*?) *🤖$/;
 
 const getTitle = (str: string) => str.match(titlePattern)?.[1];
 const getDescription = (str: string) => str.match(descriptionPattern)?.[1];


### PR DESCRIPTION
The existing 'getContent' function failed to capture contents when these were spread across multiple lines due to a '\w*' regex, which omits whitespaces making it a single-line capture. This PR fixes that issue by removing the unnecessary '\w*'.