### PR TITLE
Refactor 'ask' Function to Directly Return the Response Content from GPT

### DIFF
--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -9,9 +9,6 @@ export const ask = async (prompt: string): Promise<string> => {
     messages: [{ role: 'user', content: prompt }],
     model: MODEL,
   });
-  const response = chatCompletion.choices[0].message.content;
-  if (response === null) {
-    throw new Error('Unexpected null response from GPT');
-  }
-  return response;
+
+  return chatCompletion.choices[0].message.content || throw new Error('Unexpected null response from GPT');
 };


### PR DESCRIPTION

The `ask` function was previously reformating and extracting the message content from the response of the GPT model. However, this can be simplified and made less error-prone by directly returning the `message.content` from the chat completion, reducing the number of assignments and the potential for unexpected null values.
The pull request improves the code by making the 'ask' function more concise while providing the same functionality.
