### PR TITLE
Refactoring GitHub API Call Error Handling

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -144,6 +144,7 @@ export const createGithubPullRequest = async (
     await deleteRepository(fullOptions);
   } catch (error) {
     console.error('An error occurred:', error);
+    throw error;
   }
 };
 


### PR DESCRIPTION
This pull request focuses on refactoring the error handling for GitHub API calls in our script. Right now, our error handling is not robust - we catch errors and log them, but we do not rethrow them. This can hide failures that we might need to know about. To make debugging easier in the future, I've added a rethrow after the logging statement in each catch block so that an error in one of our API calls will cause the script to terminate and its caller to be aware of the error. This means that we fail fast, rather than attempting to execute subsequent steps that might depend on previous steps to succeed.