### PR TITLE
Refactored 'ask' Function to Use Try-Catch for Error Handling

### DIFF
--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -5,13 +5,20 @@ const openai = new OpenAI();
 const MODEL = 'gpt-4';
 
 export const ask = async (prompt: string): Promise<string> => {
-  const chatCompletion = await openai.chat.completions.create({
-    messages: [{ role: 'user', content: prompt }],
-    model: MODEL,
-  });
-  const response = chatCompletion.choices[0].message.content;
-  if (response === null) {
-    throw new Error('Unexpected null response from GPT');
+  try {
+    const chatCompletion = await openai.chat.completions.create({
+      messages: [{ role: 'user', content: prompt }],
+      model: MODEL,
+    });
+
+    const response = chatCompletion.choices[0]?.message?.content;
+  
+    if (response === null || response === undefined) {
+      throw new Error('Unexpected null or undefined response from GPT');
+    }
+
+    return response;
+  } catch (error) {
+    throw new Error(`Failed to create chat completion: ${error.message}`);
   }
-  return response;
 };


### PR DESCRIPTION
Currently, the 'ask' function directly uses the response from the 'openai.chat.completions.create' request and expects it to always return valid data. However, network requests are uncertain and may not always return the expected result. This refactor introduces a try-catch statement to the 'ask' function to handle any exceptions that might be thrown during the request to the OpenAI API. This is a valuable practice as it enables us to control the behavior of our application in the face of unpredictable network behavior and provides clearer error messages.