### PR TITLE
Enhanced Unique Branch Naming for Pull Request Creation

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,6 @@
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
+import { format } from 'date-fns';
 
 const REPOSITORY = process.env.REPOSITORY;
 const BASE_BRANCH_NAME = process.env.BRANCH;
@@ -12,6 +13,11 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
+const generateBranchName = (baseName: string): string => {
+  const dateTimeSuffix = format(new Date(), 'yyyyMMddHHmmss');
+  return `adam/${baseName}-${dateTimeSuffix}`;
+};
+
 const refactorFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
@@ -23,10 +29,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const branchName = generateBranchName(pullRequestInfo.branchName);
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: branchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

The current script uses a combination of a predefined string and a random number to generate a branch name during the pull request creation. This method, while simple, can potentially lead to collisions or a lack of descriptiveness about the changes. My refactoring introduces a timestamp-based approach, which includes a date-time prefix alongside the original branch name proposal provided by the 'refactor' function. This ensures a higher degree of uniqueness and traceability for branch names, reducing the likelihood of conflicts and providing an implicit historical context.

The use of `Math.random().toString().substring(2)` for randomness is replaced with a structured format `yyyyMMddHHmmss` to denote the exact time of branch creation, preventing accidental collisions and improving the readability and management of branches over time.
