### PR TITLE
Enforce Consistent Return Types in 'getContent' Function for Clarity and Type Safety

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -50,7 +50,7 @@ const getTitle = (str: string) => str.match(titlePattern)?.[1];
 const getDescription = (str: string) => str.match(descriptionPattern)?.[1];
 const getCommitMessage = (str: string) => str.match(commitMessagePattern)?.[1];
 const getBranchName = (str: string) => str.match(branchNamePattern)?.[1];
-const getContent = (str: string) => str.match(contentPattern)?.[1];
+const getContent = (str: string) => str.match(contentPattern)?.[1] ?? '';
 
 export default async (file: string): Promise<PullRequestInfo | undefined> => {
   const fullPrompt = PROMPT(file);


### PR DESCRIPTION

The 'getContent' function has been refactored to ensure it always returns a string type, enhancing type safety and predictability in the extraction process. Before refactoring, getContent could implicitly return 'undefined' when the regex match failed, leading to potential undefined behavior in the subsequent code. The function now explicitly returns an empty string if the match fails, upholding consistent return types and clear handling of unmatched cases.
