### PR TITLE
Improve Random Branch Name Generation in 'refactorFile' Function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -26,7 +26,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${new Date().getTime()}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

When creating a branch for a pull request, the 'refactorFile' function currently uses `Math.random().toString().substring(2)` to generate a unique identifier, which can result in non-descriptive random numbers. To make branch names more meaningful and traceable to the actual change being proposed, this pull request replaces the random number generation with a timestamp-derived string based on `new Date().getTime()`. This approach creates a more informative and chronological branch naming, making it easier to identify and manage branches cohesively.
