### PR TITLE
Renamed 'demo' function to 'runDemo' for clarity and consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import './dotenv';
-import demo from './demo';
+import runDemo from './demo';
 
-demo().catch(e => {
-  console.error('There was an error in the demo.', e);
+runDemo().catch(e => {
+  console.error('There was an error in the runDemo.', e);
 });


### PR DESCRIPTION

Renaming the 'demo' function to 'runDemo' enhances the readability and intent behind the function call. The new name signifies that the function is performing an action rather than representing a noun, making its purpose clearer to developers who may read or maintain the code. This change is particularly beneficial in larger codebases where the context of the function's usage might not be immediately clear.
