### PR TITLE
Refactor branchName Generation for Predictability and Conflict Avoidance

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,3 +1,4 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
 
@@ -23,10 +24,12 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  // Using timestamp for branch name generation.
+  const timestamp = new Date().getTime().toString();
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${timestamp}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -54,3 +57,4 @@ export default async (): Promise<void> => {
     .slice(0, 10);
   await Promise.all(filesToRefactor.map(refactorFile));
 };
+```


### PR DESCRIPTION

Currently, in the refactorFile function, we generate the new branch name using a combination of a prefix and a random number, which may lead to conflicts with existing branches or cause unpredictability in naming. To avoid potential collisions and maintain consistency, we can replace the random number with a timestamp, which provides a unique and predictable branchName for each pull request.

To improve the refactorFile function's predictability and conflict avoidance, I recommend replacing `Math.random().toString().substring(2)` with `new Date().getTime().toString()` when generating branch names. This change ensures that each branch name is unique without relying on randomness, which could potentially lead to duplicate names if the function is called in rapid succession.
