### PR TITLE
Standardize Branch Naming in refactorFile Function for Consistency with Git Flow Practices

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,15 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  
+  const sanitizedFileName = fileName.replace(/\//g, '-').replace(/\./g, '_');
+  const branchPrefix = `adam/refactor/`;
+  const branchName = `${branchPrefix}${sanitizedFileName}`;
+
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: branchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION
The refactorFile function previously generated a branch name by appending a random string to a fixed prefix 'adam/'. This approach could potentially cause confusion and does not align with common Git flow naming conventions. I have updated the function to maintain a more standardized branch naming pattern. The branchPrefix 'adam/refactor/' consistently groups refactor related branches, and the use of the fileName instead of a random string allows easier identification of the branch's purpose.

This change benefits the development process by enhancing the clarity and manageability of branch names. Clear, descriptive branch names ease navigation between branches and assist in maintaining a clean git history. Furthermore, this change aids in automation by allowing pattern-based operations on branches that share the same prefix.