### PR TITLE
Rename 'PullRequestInfo' to 'PullRequestDetails' for Clarity

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -32,7 +32,7 @@ Now that you understand how to respond, I will provide the code I would like you
 
 ${code}`;
 
-type PullRequestInfo = {
+type PullRequestDetails = {
   title: string,
   description: string,
   commitMessage: string,
@@ -52,7 +52,7 @@ const getCommitMessage = (str: string) => str.match(commitMessagePattern)?.[1];
 const getBranchName = (str: string) => str.match(branchNamePattern)?.[1];
 const getContent = (str: string) => str.match(contentPattern)?.[1];
 
-export default async (file: string): Promise<PullRequestInfo | undefined> => {
+export default async (file: string): Promise<PullRequestDetails | undefined> => {
   const fullPrompt = PROMPT(file);
   let askResponse = await ask(fullPrompt);
   const title = getTitle(askResponse);


### PR DESCRIPTION


The `PullRequestInfo` type name can be ambiguous, as 'Info' doesn't effectively communicate the nature of the type. This refactoring renames it to 'PullRequestDetails' which more accurately depicts that it contains detailed information about a pull request. This change should help future developers understand the purpose of the type more intuitively.

