### PR TITLE
Use `crypto.randomUUID()` for generating unique branch names in `refactorFile` function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,7 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
+import { randomUUID } from 'crypto';
 
 const REPOSITORY = process.env.REPOSITORY;
 const BASE_BRANCH_NAME = process.env.BRANCH;
@@ -26,7 +28,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${randomUUID()}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -54,3 +56,4 @@ export default async (): Promise<void> => {
     .slice(0, 10);
   await Promise.all(filesToRefactor.map(refactorFile));
 };
+```


### PR DESCRIPTION

The pull request updates the `refactorFile` function to improve the uniqueness and predictability of generated branch names by utilizing `crypto.randomUUID()` instead of `Math.random()`. This approach avoids potential collisions and ensures branch names are always unique as required by Git. Furthermore, it aligns with the modern practice of using built-in crypto functions for creating UUIDs.
