### PR TITLE
Improve Branch Naming by Including Timestamp in 'createGithubPullRequest' Call

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '');
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${timestamp}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

The purpose of this change is to improve the branch naming within the `createGithubPullRequest` function invocation. Instead of using a random number, we are now using a timestamp, which provides a more predictable and traceable approach to branch naming. This helps in identifying when the pull request was created and avoids possible collisions when multiple refactorings occur in a short period of time.
