### PR TITLE
Rename 'refactorFile' Function Parameter to Clarify Purpose

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -12,12 +12,12 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
-const refactorFile = async (fileName: string): Promise<void> => {
-  console.log(`Attempting to refactor ${fileName}`);
+const refactorFile = async (filePath: string): Promise<void> => {
+  console.log(`Attempting to refactor ${filePath}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
     branchName: BASE_BRANCH_NAME,
-    fileName,
+    fileName: filePath,
   });
   const pullRequestInfo = await refactor(file);
   if (pullRequestInfo === undefined) {
@@ -32,12 +32,12 @@ const refactorFile = async (fileName: string): Promise<void> => {
     description: pullRequestInfo.description,
     updates: [
       {
-        fileName,
+        fileName: filePath,
         content: pullRequestInfo.content,
       }
     ],
   });
-  console.log(`✅ Refactored ${fileName}`);
+  console.log(`✅ Refactored ${filePath}`);
 };
 
 export default async (): Promise<void> => {


### PR DESCRIPTION
Currently, the 'refactorFile' function is expecting a parameter named 'fileName' which can be confusing, as it is not immediately clear whether it requires a file name string or a file path, or if it includes the file extension. To avoid confusion and increase readability, I'm renaming the 'fileName' parameter to 'filePath' which clearly indicates that a complete file path is expected, including the name and the extension. This small change enhances the maintainability of the codebase by having self-explanatory code.