### PR TITLE
Refactor 'PROMPT' to 'createPromptTemplate' for Clear Function Intent

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -1,6 +1,6 @@
 import { ask } from '../gpt';
 
-const PROMPT = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
+const createPromptTemplate = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
 
 I will be providing a TypeScript file at the very end of this prompt. Please consider if there are any ways that you would refactor it to improve it.
 
@@ -22,7 +22,7 @@ If you do have a pull request suggestion, please respond with the following item
 
 Enclose each of these with a particular emoji so that they can be easily parsed by me. Before and after the {PULL_REQUEST_TITLE}, put the 👑 emoji. Before and after the {PULL_REQUEST_DESCRIPTION}, put the 🥔 emoji (it is okay to use multiple lines for the description, if appropriate). Before and after the {COMMIT_MESSAGE}, put the 🐴 emoji (use the "semantic commits" format for the commit message). Before and after the {BRANCH_NAME}, put the 🦀 emoji. Before and after the {COMPLETE_UPDATED_FILE_CONTENTS} (which will usually take up multiple lines), put the 🤖 emoji. For the COMPLETE_UPDATED_FILE_CONTENTS, do not use anything to enclose it other than the emoji. Do not add tick quotes or anything like that to format it.
 
-It is important that you just put the {COMPLETE_UPDATED_FILE_CONTENTS} between the emoji. ***DO NOT*** add anything else like \`\`\`typescript around the code in your response. If you add something like \`\`\`typescript around your {COMPLETE_UPDATED_FILE_CONTENTS} contents, I will be fired from my job.
+It is important that you just put the {COMPLETE_UPDATED_FILE_CONTENTS} between the emoji. ***DO NOT*** add anything else like ```typescript around the code in your response. If you add something like ```typescript around your {COMPLETE_UPDATED_FILE_CONTENTS} contents, I will be fired from my job.
 
 Remember, for the pull request title, description, commit, etc. be sure to give SPECIFIC information such as the name of the function that you refactored and how/why you improved it. "Code Quality Improvements" or "Refactor Code for Enhanced Readability and Efficacy" are bad titles. "Refactored 'ask' Function for Improved Error Handling" is better. "Provide Defaults for Missing Fields in 'ask' function" is great.
 
@@ -53,7 +53,7 @@ const getBranchName = (str: string) => str.match(branchNamePattern)?.[1];
 const getContent = (str: string) => str.match(contentPattern)?.[1];
 
 export default async (file: string): Promise<PullRequestInfo | undefined> => {
-  const fullPrompt = PROMPT(file);
+  const fullPrompt = createPromptTemplate(file);
   let askResponse = await ask(fullPrompt);
   const title = getTitle(askResponse);
   const description = getDescription(askResponse);


### PR DESCRIPTION

The refactoring focuses on improving the readability and clarity of the TypeScript file by renaming the 'PROMPT' function to 'createPromptTemplate'. This naming clearly communicates that the function is responsible for creating a template for prompts sent to the 'ask' function rather than being a constant value. This change enhances understandability for future maintainers or contributors to the code base.
