### PR TITLE
Rename 'refactorFile' Function to 'processRefactorForFile' for Clarity

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,3 +1,4 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
 
@@ -12,7 +13,11 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
-const refactorFile = async (fileName: string): Promise<void> => {
+const generateBranchName = (branchName: string): string => {
+  return `adam/${branchName}-${Math.random().toString().substring(2)}`;
+};
+
+const processRefactorForFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
@@ -23,10 +28,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const branchName = generateBranchName(pullRequestInfo.branchName);
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -52,5 +58,6 @@ export default async (): Promise<void> => {
     .sort(() => Math.random() > 0.5 ? -1 : 1)
     // Limit to 10 files
     .slice(0, 10);
-  await Promise.all(filesToRefactor.map(refactorFile));
+  await Promise.all(filesToRefactor.map(processRefactorForFile));
 };
+```


### PR DESCRIPTION

The function `refactorFile` is renamed to `processRefactorForFile` to clarify its purpose: it doesn't just refactor a file, but processes the entire refactor workflow including creating pull requests. This is a minor change but improves readability and understanding of the codebase for future maintainers or contributors.

Also, extracted the branch naming logic into a separate function `generateBranchName` for better testability and code organization. This separates concerns, making the codebase more maintainable and the logic for branch naming more explicit.
