### PR TITLE
Add Handling for Empty Pull Request Info Response in `refactorFile` Function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -19,10 +19,14 @@ const refactorFile = async (fileName: string): Promise<void> => {
     branchName: BASE_BRANCH_NAME,
     fileName,
   });
+
   const pullRequestInfo = await refactor(file);
+
   if (pullRequestInfo === undefined) {
+    console.log(`⏭ Skipped refactoring ${fileName} - No changes necessary.`);
     return;
   }
+  
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
@@ -45,6 +49,7 @@ export default async (): Promise<void> => {
     repository: REPOSITORY,
     branchName: BASE_BRANCH_NAME,
   });
+
   const filesToRefactor = files
     // Only TypeScript files
     .filter(file => file.endsWith('.ts') || file.endsWith('.tsx'))
@@ -52,5 +57,6 @@ export default async (): Promise<void> => {
     .sort(() => Math.random() > 0.5 ? -1 : 1)
     // Limit to 10 files
     .slice(0, 10);
+
   await Promise.all(filesToRefactor.map(refactorFile));
 };


### PR DESCRIPTION

When attempting to refactor a file, the `refactorFile` function currently returns early if `refactor` returns `undefined`. This indicates no pull request is needed, but it provides no feedback to the user. This can be misleading, especially if we are expecting a pull request for each file. By refactoring the `refactorFile` function to log a message when no changes are necessary, we give valuable feedback, thereby improving the transparency of the script's operation and aiding in debugging and monitoring.
