### PR TITLE
Refactor branch name generation to include timestamp for uniqueness in `refactorFile` function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,3 +1,4 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
 
@@ -23,10 +24,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const timestamp = new Date().getTime(); // Get current timestamp
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${timestamp}`, // Use timestamp for unique branch name
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -54,3 +56,4 @@ export default async (): Promise<void> => {
     .slice(0, 10);
   await Promise.all(filesToRefactor.map(refactorFile));
 };
+```


### PR DESCRIPTION

To avoid potential naming conflicts when creating multiple pull requests in quick succession, the branch name generation within the `refactorFile` function has been improved. Instead of using `Math.random()` which may cause clashes, we now incorporate a timestamp to ensure a unique name for every branch created. This tweak enhances the robustness of the script under concurrent usage scenarios.
