### PR TITLE
Renamed 'refactorFile' function for clarity and improved PR branch naming scheme

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -12,7 +12,7 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
-const refactorFile = async (fileName: string): Promise<void> => {
+const refactorAndCreateGitHubPR = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
@@ -23,10 +23,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const currentDate = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${currentDate}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -52,5 +53,5 @@ export default async (): Promise<void> => {
     .sort(() => Math.random() > 0.5 ? -1 : 1)
     // Limit to 10 files
     .slice(0, 10);
-  await Promise.all(filesToRefactor.map(refactorFile));
+  await Promise.all(filesToRefactor.map(refactorAndCreateGitHubPR));
 };


### PR DESCRIPTION
The 'refactorFile' function was ambiguously named, which might be confusing in a larger context where multiple types of refactoring might occur. Renamed to 'refactorAndCreateGitHubPR' to clarify its purpose. Additionally, included a timestamp in the branch naming scheme instead of a random number to make it more traceable and to reduce the chances of branch name collisions.

A new Date object has been used to generate an ISO string, the 'T' and following characters (time section of the ISO string) are stripped off to leave a date that's more recognizable at a glance, but still unique per day, which should suffice given the purpose of the code.