### PR TITLE
Improve Random Branch Name Generation in 'createGithubPullRequest' Call

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,3 +1,4 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
 
@@ -9,48 +10,51 @@ if (REPOSITORY === undefined) {
 }
 
 if (BASE_BRANCH_NAME === undefined) {
-  throw new Error('The BRANCH environment variable is required.');
+ throw new Error('The BRANCH environment variable is required.');
 }
 
 const refactorFile = async (fileName: string): Promise<void> => {
-  console.log(`Attempting to refactor ${fileName}`);
-  const file = await getGithubFile({
-    repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
-    fileName,
-  });
-  const pullRequestInfo = await refactor(file);
-  if (pullRequestInfo === undefined) {
-    return;
-  }
-  await createGithubPullRequest({
-    repository: REPOSITORY,
-    baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
-    commitMessage: pullRequestInfo.commitMessage,
-    title: pullRequestInfo.title,
-    description: pullRequestInfo.description,
-    updates: [
-      {
-        fileName,
-        content: pullRequestInfo.content,
-      }
-    ],
-  });
-  console.log(`✅ Refactored ${fileName}`);
+ console.log(`Attempting to refactor ${fileName}`);
+ const file = await getGithubFile({
+   repository: REPOSITORY,
+   branchName: BASE_BRANCH_NAME,
+   fileName,
+ });
+ const pullRequestInfo = await refactor(file);
+ if (pullRequestInfo === undefined) {
+   return;
+ }
+ // Use a timestamp to create a unique branch name related to the refactoring task
+ const timestamp = new Date().toISOString().replace(/[^0-9]/g, '');
+ await createGithubPullRequest({
+   repository: REPOSITORY,
+   baseBranchName: BASE_BRANCH_NAME,
+   branchName: `adam/${pullRequestInfo.branchName}-${timestamp}`,
+   commitMessage: pullRequestInfo.commitMessage,
+   title: pullRequestInfo.title,
+   description: pullRequestInfo.description,
+   updates: [
+     {
+       fileName,
+       content: pullRequestInfo.content,
+     }
+   ],
+ });
+ console.log(`✅ Refactored ${fileName}`);
 };
 
 export default async (): Promise<void> => {
-  const files = await getGithubFiles({
-    repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
-  });
-  const filesToRefactor = files
-    // Only TypeScript files
-    .filter(file => file.endsWith('.ts') || file.endsWith('.tsx'))
-    // Randomize the order
-    .sort(() => Math.random() > 0.5 ? -1 : 1)
-    // Limit to 10 files
-    .slice(0, 10);
-  await Promise.all(filesToRefactor.map(refactorFile));
+ const files = await getGithubFiles({
+   repository: REPOSITORY,
+   branchName: BASE_BRANCH_NAME,
+ });
+ const filesToRefactor = files
+   // Only TypeScript files
+   .filter(file => file.endsWith('.ts') || file.endsWith('.tsx'))
+   // Randomize the order
+   .sort(() => Math.random() > 0.5 ? -1 : 1)
+   // Limit to 10 files
+   .slice(0, 10);
+ await Promise.all(filesToRefactor.map(refactorFile));
 };
+``` 


### PR DESCRIPTION
Currently, the branch name generation in the `createGithubPullRequest` call within the `refactorFile` function relies on the addition of a random number to avoid name collisions. This method is non-deterministic and can potentially lead to unexpected results or collisions. This pull request introduces a time-based approach using a timestamp to create a unique and traceable branch name.