### PR TITLE
Rename 'BASE_BRANCH_NAME' to 'TARGET_BRANCH' for Clarity in TypeScript Refactor Script

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -2,13 +2,13 @@ import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github
 import refactor from './prompts/refactor';
 
 const REPOSITORY = process.env.REPOSITORY;
-const BASE_BRANCH_NAME = process.env.BRANCH;
+const TARGET_BRANCH = process.env.BRANCH;
 
 if (REPOSITORY === undefined) {
   throw new Error('The REPOSITORY environment variable is required.');
 }
 
-if (BASE_BRANCH_NAME === undefined) {
+if (TARGET_BRANCH === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
@@ -16,7 +16,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
+    branchName: TARGET_BRANCH,
     fileName,
   });
   const pullRequestInfo = await refactor(file);
@@ -25,7 +25,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   }
   await createGithubPullRequest({
     repository: REPOSITORY,
-    baseBranchName: BASE_BRANCH_NAME,
+    baseBranchName: TARGET_BRANCH,
     branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
@@ -43,7 +43,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
 export default async (): Promise<void> => {
   const files = await getGithubFiles({
     repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
+    branchName: TARGET_BRANCH,
   });
   const filesToRefactor = files
     // Only TypeScript files


### PR DESCRIPTION

The term 'BASE_BRANCH_NAME' could be ambiguous when referring to the branch that changes are being compared against; in the context of a pull request, the 'base' is often considered the destination, where changes will merge into. Hence, renaming 'BASE_BRANCH_NAME' to 'TARGET_BRANCH' can provide better clarity on its role. Some supporting environments and toolchains interpret 'BASE_BRANCH' as the starting point of the change, similar to feature or topic branches. Therefore 'TARGET_BRANCH' can eliminate potential confusion.

This change will improve the readability and clarity of the script by indicating that 'TARGET_BRANCH' is the branch into which the pull request is intended to be merged.
