### PR TITLE
Improve Error Logging for Failed 'refactorFile' Operations

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -19,14 +19,18 @@ const refactorFile = async (fileName: string): Promise<void> => {
     branchName: BASE_BRANCH_NAME,
     fileName,
   });
+
   const pullRequestInfo = await refactor(file);
   if (pullRequestInfo === undefined) {
+    console.error(`Failed to refactor ${fileName}: pullRequestInfo is undefined.`);
     return;
   }
+
+  const refactoredBranchName = `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`;
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: refactoredBranchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION
Currently, when attempts to refactor a file in the 'refactorFile' function fail due to an undefined 'pullRequestInfo', the process fails silently, making debugging difficult. This change aims to enhance error visibility and debugging by logging a message when the refactoring process does not result in a pull request.