### PR TITLE
Improve Random Branch Names in 'createGithubPullRequest' Call

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '');
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${timestamp}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

In an effort to create more traceable branch names for pull requests, the random number used in the branch name within the 'createGithubPullRequest' function call has been replaced with a timestamp. This makes it easier to identify when the branch was created and associates the pull request more closely with the refactoring session.

Timestamps in branch names offer predictability and improve traceability over purely random numbers, aiding in better managing branches when multiple refactoring sessions take place.
