### PR TITLE
Improve random branch name generation in 'createGithubPullRequest' call by using a UUID

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,4 +1,5 @@
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
+import { v4 as uuidv4 } from 'uuid';
 import refactor from './prompts/refactor';
 
 const REPOSITORY = process.env.REPOSITORY;
@@ -26,7 +27,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${uuidv4()}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

Currently, the implementation for creating a random branch name in the 'createGithubPullRequest' call is using the `Math.random().toString()` method. This method can potentially result in collisions and does not guarantee unique branch names. Refactoring this to use a UUID (Universally Unique Identifier) will improve the robustness of the branch name generation. This change ensures that every branch name created is unique and avoids potential conflicts when multiple refactor operations occur simultaneously.
