### PR TITLE
Rename 'fetchDirectoryContents' for clear scope in 'getGithubFiles'

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -173,7 +173,7 @@ type GetFilesOptions = {
 };
 
 export const getGithubFiles = async (options: GetFilesOptions): Promise<string[]> => {
-  const fetchDirectoryContents = async (path: string = ''): Promise<string[]> => {
+  const fetchDirectoryFilesRecursive = async (path: string = ''): Promise<string[]> => {
     const url = `https://api.github.com/repos/${options.repository}/contents/${path}?ref=${options.branchName}`;
     const response = await fetch(url, {
       headers: {
@@ -193,7 +193,7 @@ export const getGithubFiles = async (options: GetFilesOptions): Promise<string[]
       if (item.type === 'file') {
         files.push(item.path);
       } else if (item.type === 'dir') {
-        const subdirectoryFiles = await fetchDirectoryContents(item.path);
+        const subdirectoryFiles = await fetchDirectoryFilesRecursive(item.path);
         files = files.concat(subdirectoryFiles);
       }
     }
@@ -202,7 +202,7 @@ export const getGithubFiles = async (options: GetFilesOptions): Promise<string[]
   };
 
   try {
-    return await fetchDirectoryContents();
+    return await fetchDirectoryFilesRecursive();
   } catch (error) {
     console.error('Error fetching repository files:', error);
     throw error;


### PR DESCRIPTION

The 'fetchDirectoryContents' method inside 'getGithubFiles' is recursively called to fetch files
from a GitHub repository. Since this function is used only within the 'getGithubFiles', it would be
more readable and easier to understand if its name reflected its scope as an internal function.
The function has been renamed to 'fetchDirectoryFilesRecursive' to communicate that it's used for
recursively fetching files within directories and to clarify that it only serves an internal purpose
within the 'getGithubFiles' method.
