### PR TITLE
Improved Branch Naming Scheme for Pull Requests in 'refactorFile' function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const timestamp = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/refactor-${fileName.replace(/\./g, '-')}-${timestamp}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

The 'refactorFile' function currently generates a branch name by combining a prefix, the branch name, and a random number. This is problematic because the random component makes it difficult to understand at a glance what changes the branch contains, thus complicating maintaining multiple branches. I propose a new naming scheme that removes the random component and instead includes the filename being refactored. This will improve maintainability and context recognition for pull requests.

Additionally, appending a timestamp to the branch name ensures uniqueness across multiple refactor attempts on the same file, without resorting to an opaque random number. This timestamp also provides a clear chronological context for when the refactoring attempts were made.
