### PR TITLE
Rename 'refactorFile' to 'refactorAndCreatePullRequest' to clarify intent

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -12,7 +12,7 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
-const refactorFile = async (fileName: string): Promise<void> => {
+const refactorAndCreatePullRequest = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
@@ -37,7 +37,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
       }
     ],
   });
-  console.log(`✅ Refactored ${fileName}`);
+  console.log(`✅ Refactored and created pull request for ${fileName}`);
 };
 
 export default async (): Promise<void> => {
@@ -52,5 +52,5 @@ export default async (): Promise<void> => {
     .sort(() => Math.random() > 0.5 ? -1 : 1)
     // Limit to 10 files
     .slice(0, 10);
-  await Promise.all(filesToRefactor.map(refactorFile));
+  await Promise.all(filesToRefactor.map(refactorAndCreatePullRequest));
 };


### PR DESCRIPTION

This refactor clarifies the purpose of the 'refactorFile' function by renaming it to 'refactorAndCreatePullRequest'. The previous name did not convey that the function was responsible for creating a pull request after refactoring. This change improves readability and makes the codebase easier to understand.

By renaming the function, new contributors and team members can better understand the workflow and logic without needing to dive into the implementation details immediately. Additionally, the updated name matches the actual side effects of the function, ensuring that the naming conventions provide an accurate description of the functionality.
