### PR TITLE
Standardize branch naming in refactorFile to enhance clarity and predictability

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,13 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  // Create a standardized branch name
+  const timestamp = new Date().getTime();
+  const standardizedBranchName = `adam/refactor-${fileName.replace(/\//g, '-')}-${timestamp}`;
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: standardizedBranchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

To foster a more consistent and clear Git workflow, we're standardizing the branch naming pattern used during the dynamic creation of branches for refactoring tasks. The current usage of Math.random() leads to branches with unpredictable names, making them harder to recognize and manage. The new convention includes the filename being refactored and a timestamp, resulting in more informative branch names such as 'adam/refactor-index-component-16645454589'. This change aids in better tracking the relationship between tasks and their branches, as well as simplifies locating branches for specific updates.
