### PR TITLE
Provide Default Branch Name for 'refactor' Module to Avoid Random Named Branches

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -12,6 +12,10 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
+const timestamp = () => {
+  return new Date().toISOString().replace(/[^0-9]/g, "").slice(0,14);
+};
+
 const refactorFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
@@ -26,7 +30,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${timestamp()}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

The current implementation of the 'refactorFile' function generates a new random branch name every time it creates a pull request for a refactored file. While randomization ensures uniqueness, it can clutter the repository with unintuitive branch names. This refactoring assigns a consistent, timestamp-based suffix for the branch names created by this function, for better traceability and organization in the repository branches.

The proposed change enhances the readability and manageability of branches by using a uniform naming convention that includes a timestamp. This will make it easier to track when each change was suggested and associate pull requests with the time of their creation.
