### PR TITLE
Renamed 'PROMPT' Template Literal Function for Clarity

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -1,6 +1,6 @@
 import { ask } from '../gpt';
 
-const PROMPT = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
+const generatePrompt = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
 
 I will be providing a TypeScript file at the very end of this prompt. Please consider if there are any ways that you would refactor it to improve it.
 
@@ -53,7 +53,7 @@ const getBranchName = (str: string) => str.match(branchNamePattern)?.[1];
 const getContent = (str: string) => str.match(contentPattern)?.[1];
 
 export default async (file: string): Promise<PullRequestInfo | undefined> => {
-  const fullPrompt = PROMPT(file);
+  const fullPrompt = generatePrompt(file);
   let askResponse = await ask(fullPrompt);
   const title = getTitle(askResponse);
   const description = getDescription(askResponse);


### PR DESCRIPTION

Refactoring the 'PROMPT' named template literal function in order to better reflect its purpose and usage within the 'ask' function invocation pattern. The original name 'PROMPT' may suggest it is a constant; therefore, renaming it to 'generatePrompt' clarifies its behavior as a function that generates a prompt string based on provided code.
