### PR TITLE
Improve random branch naming in refactorFile function by ensuring uniqueness

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,10 +23,15 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  // Ensure the branch name is unique by using the current timestamp and a random number
+  const timestamp = new Date().getTime();
+  const randomSequence = Math.random().toString().substring(2);
+  const uniqueBranchName = `adam/${pullRequestInfo.branchName}-${timestamp}-${randomSequence}`;
+
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: uniqueBranchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION

The current implementation for generating a random branch name within refactorFile is using `Math.random()`. This could potentially lead to collisions in branch names if the function is executed in rapid succession or multiple times concurrently. By using the current timestamp concatenated with the random number, it increases the uniqueness of the branch name and reduces the likelihood of collisions. This change is especially important for ensuring that each generated branch name is unique in automated or high-frequency scenarios.
