### PR TITLE
Renamed 'e' to 'error' for clarity in catch block of demo execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import './dotenv';
 import demo from './demo';
 
-demo().catch(e => {
-  console.error('There was an error in the demo.', e);
+demo().catch(error => {
+  console.error('There was an error in the demo.', error);
 });


### PR DESCRIPTION

The variable `e` in the catch block for the demo execution was renamed to `error` to improve clarity and readability. This follows best practices for variable naming by making it more descriptive and understandable at a glance, which can make understanding and debugging the code easier.
