### PR TITLE
Rename 'MODEL' to 'GPT_MODEL' for Clearer Context

### DIFF
--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -2,12 +2,12 @@ import OpenAI from 'openai';
 
 const openai = new OpenAI();
 
-const MODEL = 'gpt-4-1106-preview';
+const GPT_MODEL = 'gpt-4-1106-preview';
 
 export const ask = async (prompt: string): Promise<string> => {
   const chatCompletion = await openai.chat.completions.create({
     messages: [{ role: 'user', content: prompt }],
-    model: MODEL,
+    model: GPT_MODEL,
   });
   const response = chatCompletion.choices[0].message.content;
   if (response === null) {


### PR DESCRIPTION

The 'MODEL' constant in the TypeScript file describes the model used for OpenAI requests. The current naming is not explicitly tied to OpenAI and could be misleading in larger codebases. My suggestion is to rename 'MODEL' to 'GPT_MODEL' to provide clearer context for what the constant represents within the scope of interacting with the OpenAI API. This makes the code more understandable and maintainable, especially for developers unfamiliar with the specifics of the OpenAI implementation.
