### PR TITLE
Rename function 'PROMPT' for clarity and improved semantics

### DIFF
--- a/src/prompts/refactor.ts
+++ b/src/prompts/refactor.ts
@@ -1,6 +1,6 @@
 import { ask } from '../gpt';
 
-const PROMPT = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
+const createPromptTemplate = (code: string): string => `Hello! Please assume the role of an experienced and talented software engineer named ADAM.
 
 I will be providing a TypeScript file at the very end of this prompt. Please consider if there are any ways that you would refactor it to improve it.
 
@@ -53,7 +53,7 @@ const getBranchName = (str: string) => str.match(branchNamePattern)?.[1];
 const getContent = (str: string) => str.match(contentPattern)?.[1];
 
 export default async (file: string): Promise<PullRequestInfo | undefined> => {
-  const fullPrompt = PROMPT(file);
+  const fullPrompt = createPromptTemplate(file);
   let askResponse = await ask(fullPrompt);
   const title = getTitle(askResponse);
   const description = getDescription(askResponse);


### PR DESCRIPTION

The 'PROMPT' function currently suggests an action is taking place, whereas it is actually returning a template string. To improve semantic understanding and maintainability, the function has been refactored to 'createPromptTemplate'. This name clarifies intent and adheres to common best practices for naming functions that return values without performing actions.
