### PR TITLE
Rename 'BASE_BRANCH_NAME' to 'TARGET_BRANCH_NAME' for Clarity

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -2,13 +2,13 @@ import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github
 import refactor from './prompts/refactor';
 
 const REPOSITORY = process.env.REPOSITORY;
-const BASE_BRANCH_NAME = process.env.BRANCH;
+const TARGET_BRANCH_NAME = process.env.BRANCH;
 
 if (REPOSITORY === undefined) {
   throw new Error('The REPOSITORY environment variable is required.');
 }
 
-if (BASE_BRANCH_NAME === undefined) {
+if (TARGET_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
@@ -16,7 +16,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
     repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
+    branchName: TARGET_BRANCH_NAME,
     fileName,
   });
   const pullRequestInfo = await refactor(file);
@@ -25,7 +25,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   }
   await createGithubPullRequest({
     repository: REPOSITORY,
-    baseBranchName: BASE_BRANCH_NAME,
+    baseBranchName: TARGET_BRANCH_NAME,
     branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
@@ -43,7 +43,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
 export default async (): Promise<void> => {
   const files = await getGithubFiles({
     repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
+    branchName: TARGET_BRANCH_NAME,
   });
   const filesToRefactor = files
     // Only TypeScript files


### PR DESCRIPTION

The existing variable name 'BASE_BRANCH_NAME' can be misleading, as it may imply the starting point of a branch rather than its target or destination. To prevent confusion and add clarity to the codebase, the variable name has been changed to 'TARGET_BRANCH_NAME' which conveys its intent more accurately.
