### PR TITLE
Encapsulate Pull Request Creation in a Dedicated Function

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -12,17 +12,7 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
-const refactorFile = async (fileName: string): Promise<void> => {
-  console.log(`Attempting to refactor ${fileName}`);
-  const file = await getGithubFile({
-    repository: REPOSITORY,
-    branchName: BASE_BRANCH_NAME,
-    fileName,
-  });
-  const pullRequestInfo = await refactor(file);
-  if (pullRequestInfo === undefined) {
-    return;
-  }
+const createPullRequestForRefactor = async (fileName: string, pullRequestInfo: any): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
@@ -37,6 +27,21 @@ const refactorFile = async (fileName: string): Promise<void> => {
       }
     ],
   });
+};
+
+const refactorFile = async (fileName: string): Promise<void> => {
+  console.log(`Attempting to refactor ${fileName}`);
+  const file = await getGithubFile({
+    repository: REPOSITORY,
+    branchName: BASE_BRANCH_NAME,
+    fileName,
+  });
+  const pullRequestInfo = await refactor(file);
+  if (pullRequestInfo === undefined) {
+    return;
+  }
+
+  await createPullRequestForRefactor(fileName, pullRequestInfo);
   console.log(`✅ Refactored ${fileName}`);
 };
 
@@ -45,12 +50,11 @@ export default async (): Promise<void> => {
     repository: REPOSITORY,
     branchName: BASE_BRANCH_NAME,
   });
+  
   const filesToRefactor = files
-    // Only TypeScript files
     .filter(file => file.endsWith('.ts') || file.endsWith('.tsx'))
-    // Randomize the order
     .sort(() => Math.random() > 0.5 ? -1 : 1)
-    // Limit to 10 files
     .slice(0, 10);
+
   await Promise.all(filesToRefactor.map(refactorFile));
 };


### PR DESCRIPTION

The provided TypeScript file currently has logic to create a GitHub pull request within the 'refactorFile' function. To adhere to the single-responsibility principle and improve code reusability, I recommend encapsulating the logic for creating a pull request in a dedicated function called 'createPullRequestForRefactor'. This improvement makes the 'refactorFile' function more concise and focused solely on refactoring logic, while also allowing other parts of the codebase to use the pull request creation functionality without duplication of logic.
