### PR TITLE
Improve randomness in 'refactorFile' branch naming with more robust UUID

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,7 @@
+```typescript
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
+import { randomUUID } from 'crypto';
 
 const REPOSITORY = process.env.REPOSITORY;
 const BASE_BRANCH_NAME = process.env.BRANCH;
@@ -26,7 +28,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: `adam/${pullRequestInfo.branchName}-${randomUUID()}`,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,
@@ -54,3 +56,4 @@ export default async (): Promise<void> => {
     .slice(0, 10);
   await Promise.all(filesToRefactor.map(refactorFile));
 };
+```


### PR DESCRIPTION

The 'refactorFile' function constructs a new branch name with a combination of a hard-coded prefix and a random number. This method may lead to potential collisions and is not as random as it could be. This change replaces `Math.random().toString().substring(2)` with `crypto.randomUUID()` to generate a more robust and unique identifier for new branches.
