### PR TITLE
Enhance 'refactorFile' Function with Deterministic Branch Naming

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,6 @@
 import { createGithubPullRequest, getGithubFile, getGithubFiles } from './github';
 import refactor from './prompts/refactor';
+import crypto from 'crypto';
 
 const REPOSITORY = process.env.REPOSITORY;
 const BASE_BRANCH_NAME = process.env.BRANCH;
@@ -12,6 +13,11 @@ if (BASE_BRANCH_NAME === undefined) {
   throw new Error('The BRANCH environment variable is required.');
 }
 
+const generateBranchName = (base: string, content: string): string => {
+  const hash = crypto.createHash('sha1').update(content).digest('hex').substring(0, 7);
+  return `adam/${base}-${hash}`;
+};
+
 const refactorFile = async (fileName: string): Promise<void> => {
   console.log(`Attempting to refactor ${fileName}`);
   const file = await getGithubFile({
@@ -23,10 +29,11 @@ const refactorFile = async (fileName: string): Promise<void> => {
   if (pullRequestInfo === undefined) {
     return;
   }
+  const branchName = generateBranchName(pullRequestInfo.branchName, pullRequestInfo.content);
   await createGithubPullRequest({
     repository: REPOSITORY,
     baseBranchName: BASE_BRANCH_NAME,
-    branchName: `adam/${pullRequestInfo.branchName}-${Math.random().toString().substring(2)}`,
+    branchName: branchName,
     commitMessage: pullRequestInfo.commitMessage,
     title: pullRequestInfo.title,
     description: pullRequestInfo.description,


### PR DESCRIPTION
Currently, the 'refactorFile' function generates a non-deterministic branch name, which might lead to confusion and difficulty in tracking issues over multiple runs, especially if a pull request is closed without merging and later needs revisiting. This refactor replaces the random number generation with a short SHA-1 hash of the file content, ensuring a unique but deterministic branch name for each file's changes.