### PR TITLE
Improve Error Handling by Reporting Failed Refactor Attempts for Files

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -21,6 +21,7 @@ const refactorFile = async (fileName: string): Promise<void> => {
   });
   const pullRequestInfo = await refactor(file);
   if (pullRequestInfo === undefined) {
+    console.error(`❌ Failed to refactor ${fileName}`);
     return;
   }
   await createGithubPullRequest({


### PR DESCRIPTION

Currently, when the `refactorFile` function in the script encounters a file that cannot be refactored (i.e., if the `refactor` function returns undefined), it silently returns without any indication of failure. This pull request introduces a simple logging mechanism to report back to the user whenever a file's refactoring attempt fails. This change furthers transparency and eases debugging by clearly indicating which files, if any, were not successfully refactored.

By informing the user about the specific files that could not be refactored, we prevent silent failures and ensure better operational visibility when the script runs.
